### PR TITLE
Reordering pipelines in prompt_pwd formatting

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -28,9 +28,9 @@ function fish_right_prompt
   set -l base (basename "$PWD")
 
   if test "$PWD" != "/"
-    prompt_pwd | sed "s|~|"(hulk::status::color)"ᴦ"(off)"|g" \
-    | sed "s|/|"(hulk::status::color)"/"(off)(hulk::dim)"|g" \
-    | sed "s|$base|"(hulk::trd)" $base"(off)"|g"
+    prompt_pwd | sed "s|$base|"(hulk::trd)" $base"(off)"|g" \
+    | sed "s|~|"(hulk::status::color)"ᴦ"(off)"|g" \
+    | sed "s|/|"(hulk::status::color)"/"(off)(hulk::dim)"|g"
   end
 
   if test -d .git


### PR DESCRIPTION
There's a problem with `prompt_pwd` formatting when your base directory is present as an escape code substring. A simple way to reproduce the problem is this
```
$ mkdir 2
$ cd 2
```
All you need to fix that is rearrange the order of pipelines in `prompt_pwd` formatting.