### PR TITLE
Print branch name when not in git repo root

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -33,7 +33,7 @@ function fish_right_prompt
     | sed "s|$base|"(hulk::trd)" $base"(off)"|g"
   end
 
-  if test -d .git
+  if git_is_repo
     echo (hulk::status::color)" ≡ "(hulk::snd)(begin
       git_is_touched; and hulk::branch_name; or echo (hulk::dim)(hulk::branch_name)
     end)(off)


### PR DESCRIPTION
The function has more comprehensive checks. i.e. if we're not in the root of the repo, it will still recognize we're in a git repo.